### PR TITLE
fix: configure correct base path for GitHub Pages deployment

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,5 +10,5 @@ export default defineConfig({
   preview: {
     port: 8080
   },
-  base: '/'
+  base: '/ai-coding-as-a-blackbox/'
 })


### PR DESCRIPTION
Fixes #7

The frontend wasn't loading on GitHub Pages because assets were being requested from the wrong path. This PR fixes the issue by:

- Setting the correct base path `/ai-coding-as-a-blackbox/` in vite.config.ts
- Ensuring all assets (CSS, JS, SVG) are served from the correct GitHub Pages path
- Resolving 404 errors that caused the blank page

Generated with [Claude Code](https://claude.ai/code)