### PR TITLE
fix: Update page title and add missing step definition

### DIFF
--- a/acceptance-tests/features/step_definitions/steps.js
+++ b/acceptance-tests/features/step_definitions/steps.js
@@ -87,3 +87,8 @@ Then('the {string} and {string} should have the same width', async (selector1, s
 
   expect(width1).to.equal(width2);
 });
+
+Then('the page title should equal {string}', async (expectedTitle) => {
+  const actualTitle = await page.title();
+  expect(actualTitle).to.equal(expectedTitle);
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>AI Coding - Login</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
Fixes acceptance test failures in check-login.feature by:

- Adding missing step definition for 'page title should equal' test
- Updating HTML title from 'Vite + React + TS' to 'AI Coding - Login'

Closes #9

Generated with [Claude Code](https://claude.ai/code)