### PR TITLE
fix: Set correct base path for GitHub Pages deployment

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,5 +13,5 @@ export default defineConfig({
     port: 8080,
     open: false
   },
-  base: '/'
+  base: '/ai-coding-as-a-blackbox/'
 })


### PR DESCRIPTION
Fixes the white screen issue on the published GitHub Pages site by setting the correct base path in vite.config.ts.

Changes:
- Updated base path from '/' to '/ai-coding-as-a-blackbox/'
- This matches the GitHub Pages URL structure
- All assets will now load correctly

Fixes #17

Generated with [Claude Code](https://claude.ai/code)